### PR TITLE
Update commands to match npm scripts

### DIFF
--- a/custom-login/README.md
+++ b/custom-login/README.md
@@ -52,7 +52,7 @@ Now place these values into the file `.samples.config.json` that was created for
 Now start the app server:
 
 ```
-npm run custom-login
+npm run custom-login-server
 ```
 
 Now navigate to http://localhost:8080 in your browser.

--- a/okta-hosted-login/README.md
+++ b/okta-hosted-login/README.md
@@ -53,7 +53,7 @@ Now place these values into the file `.samples.config.json` that was created for
 Now start the app server:
 
 ```
-npm run okta-hosted-login
+npm run okta-hosted-login-server
 ```
 
 Now navigate to http://localhost:8080 in your browser.


### PR DESCRIPTION
These commands in the readme should match what's in package.json. Otherwise, I get this by following the readme:

```
C:\Users\Nate\Documents\code\samples-nodejs-express-4> npm run custom-login
npm ERR! missing script: custom-login

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\Nate\AppData\Roaming\npm-cache\_logs\2018-01-18T23_43_23_626Z-debug.log
```