### PR TITLE
Fixes selenium version to 3.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "test:resource-server": "jasmine okta-oidc-tck/resource-server/specs/okta-resource-server-spec.js",
     "test": "npm run test:e2e",
     "test:e2e": "npm run test:okta-hosted-login && npm run test:custom-login && npm run test:resource-server",
-    "pretest": "webdriver-manager update --gecko false && node scripts/setup-env.js",
-    "webdriver-update-2.45": "webdriver-manager update --versions.chrome 2.45 --gecko false && node scripts/setup-env.js"
+    "pretest": "webdriver-manager update --versions.standalone=3.141.59 --gecko false && node scripts/setup-env.js",
+    "webdriver-update-2.45": "webdriver-manager update --versions.standalone=3.141.59 --versions.chrome 2.45 --gecko false && node scripts/setup-env.js"
   },
   "devDependencies": {
     "dotenv": "^5.0.1",


### PR DESCRIPTION
* Nightly jobs have been [failing](https://travis-ci.org/okta/samples-nodejs-express-4/builds/526123613) on travis due to automatic update of selenium
* This changes hard codes the selenium version and fixes the failure