### PR TITLE
support testenv, log errors

### DIFF
--- a/common/sample-web-server.js
+++ b/common/sample-web-server.js
@@ -84,11 +84,16 @@ module.exports = function SampleWebServer(sampleConfig, extraOidcOptions, homePa
   });
 
   oidc.on('ready', () => {
+    // eslint-disable-next-line no-console
     app.listen(sampleConfig.port, () => console.log(`App started on port ${sampleConfig.port}`));
   });
 
   oidc.on('error', err => {
     // An error occurred with OIDC
-    throw err;
+    // eslint-disable-next-line no-console
+    console.error('OIDC ERROR: ', err);
+
+    // Throwing an error will terminate the server process
+    // throw err;
   });
 };

--- a/config.js
+++ b/config.js
@@ -1,7 +1,15 @@
-var path = require('path');
+const path = require('path');
+const dotenv = require('dotenv');
+const fs = require('fs');
 
-// Users can also provide the testenv configuration at the root folder: https://www.npmjs.com/package/dotenv
-require('dotenv').config({ path: path.join(__dirname, 'testenv') });
+// Read environment variables from "testenv". Override environment vars if they are already set. https://www.npmjs.com/package/dotenv
+const TESTENV = path.resolve(__dirname, 'testenv');
+if (fs.existsSync(TESTENV)) {
+  const envConfig = dotenv.parse(fs.readFileSync(TESTENV));
+  Object.keys(envConfig).forEach((k) => {
+    process.env[k] = envConfig[k];
+  });
+}
 
 var ISSUER = process.env.ISSUER || 'https://{yourOktaDomain}.com/oauth2/default';
 var CLIENT_ID = process.env.CLIENT_ID || '{clientId}';


### PR DESCRIPTION
- support standard `testenv` file
- log errors instead of throw 