### PR TITLE
Move dotenv from devDependencies to dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "axios": "^0.20.0",
-    "dotenv": "^8.2.0",
     "find-process": "^1.4.3",
     "forever-monitor": "^3.0.2",
     "jasmine": "^3.6.1",
@@ -38,6 +37,7 @@
     "@okta/oidc-middleware": "^4.0.1",
     "colors": "^1.4.0",
     "cors": "^2.8.5",
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-session": "^1.17.1",
     "mustache-express": "^1.3.0"


### PR DESCRIPTION
### Description
Moves `dotenv` from `dependencies` to `devDepencies` in `package.json`. `dotenv` is a runtime dependency, and this change will fix issues if `NODE_ENV=production` or other causes under which dependencies are installed but not devDependencies.

**Prior behavior**
* `export NODE_ENV=production`
* `npm install`
* `ISSUER={validOktaDomain}/oauth2/default CLIENT_ID={validClientId} CLIENT_SECRET={validClientSecret} npm run okta-hosted-login-server`

Resulted in:
```
> @okta/samples-nodejs-express-4@3.1.0 okta-hosted-login-server
> node okta-hosted-login/server.js

internal/modules/cjs/loader.js:883
  throw err;
  ^

Error: Cannot find module 'dotenv'
Require stack:
- /(...)/samples-nodejs-express-4/config.js
- /(...)/samples-nodejs-express-4/okta-hosted-login/server.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
    at Function.Module._load (internal/modules/cjs/loader.js:725:27)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/Users/derek.tiffany/Documents/GitHub/samples-nodejs-express-4/config.js:2:16)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/(...)/samples-nodejs-express-4/config.js',
    '/(...)/samples-nodejs-express-4/okta-hosted-login/server.js'
  ]
}
```
**New behavior**

The above now results in:
```
> @okta/samples-nodejs-express-4@3.1.0 okta-hosted-login-server
> node okta-hosted-login/server.js

(...)
App started on port 8080
```

### Resolves
#114 